### PR TITLE
added constraints for album cover thumbnail size

### DIFF
--- a/MMM-KEXP.njk
+++ b/MMM-KEXP.njk
@@ -1,3 +1,11 @@
+<!-- This CSS code limits the size of the album art thumbnail -->
+<style>
+  img {
+    max-width: 250px;
+    height: auto;
+  }
+</style>
+
 <div>
   <div>
     <img


### PR DESCRIPTION
Added constraints for thumbnail size of album art to prevent the image from taking over the whole magic mirror.